### PR TITLE
Fixed formState onChange event to properly set a value as false

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -95,7 +95,7 @@ export default class Form extends Component {
             value = event.target.checked;
           }
         }
-        formState.set(key, value || '');
+        formState.set(key, typeof value === 'undefined' ? '' : value);
       },
     };
   }


### PR DESCRIPTION
If the form element is a checkbox and the checked value = false, it was setting the formState value as "" (empty string).